### PR TITLE
Extend config with cookie settings

### DIFF
--- a/projects/universal-cookie-consent/src/lib/helpers/cookie.helper.ts
+++ b/projects/universal-cookie-consent/src/lib/helpers/cookie.helper.ts
@@ -6,9 +6,14 @@ export const UNIVERSAL_COOKIE_CONSENT_NAMESPACE = 'ucc';
  * Write a new key value pair to the cookies
  * @param key
  * @param value
+ * @param options
  */
-export function writeCookie<T>(key: string, value: T) {
-    Cookies.set(`${UNIVERSAL_COOKIE_CONSENT_NAMESPACE}_${key}`, JSON.stringify(value));
+export function writeCookie<T>(key: string, value: T, options?: any) {
+    if (options) {
+        Cookies.set(`${UNIVERSAL_COOKIE_CONSENT_NAMESPACE}_${key}`, JSON.stringify(value), options);
+    } else {
+        Cookies.set(`${UNIVERSAL_COOKIE_CONSENT_NAMESPACE}_${key}`, JSON.stringify(value));
+    }
 }
 
 /**

--- a/projects/universal-cookie-consent/src/lib/models/universal-cookie-consent-options.model.ts
+++ b/projects/universal-cookie-consent/src/lib/models/universal-cookie-consent-options.model.ts
@@ -43,4 +43,8 @@ export interface UniversalCookieConsentOptions {
 
     saveText?: string;
 
+    cookieSettings?: {
+        expires: string;
+    };
+
 }

--- a/projects/universal-cookie-consent/src/lib/services/universal-cookie-consent.service.ts
+++ b/projects/universal-cookie-consent/src/lib/services/universal-cookie-consent.service.ts
@@ -120,7 +120,8 @@ export class UniversalCookieConsentService {
      */
     protected onConsentsUpdated(consents: string[] | null) {
         if (consents !== null) {
-            writeCookie(UNIVERSAL_COOKIE_CONSENT_CONSENTS_KEY, consents);
+            const cookieSettings = this.options$.value.cookieSettings;
+            writeCookie(UNIVERSAL_COOKIE_CONSENT_CONSENTS_KEY, consents, cookieSettings);
         } else {
             clearCookie(UNIVERSAL_COOKIE_CONSENT_CONSENTS_KEY);
         }


### PR DESCRIPTION
Currently there is no expiration date set when writing a cookie so it is valid for this session. So everytime we open the browser again, we will see the cookie consent.
So I have added cookie settings to the config which will be used when a cookie will be written.